### PR TITLE
Collapsible menu integrated

### DIFF
--- a/src/components/NavBar/index.js
+++ b/src/components/NavBar/index.js
@@ -3,7 +3,9 @@ import { Layout, Menu } from 'antd';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
-const { Header } = Layout;
+const { Header, Sider } = Layout;
+// Window width of 500px
+const mobileWidthBreak = 500;
 
 class NavBar extends Component {
   constructor(props) {
@@ -11,6 +13,7 @@ class NavBar extends Component {
     const { selectedKeys } = this.props;
     this.state = {
       selectedKeys,
+      windowWidth: window.innerWidth,
     };
     this.setSelectedKeys = this.setSelectedKeys.bind(this);
   }
@@ -21,21 +24,61 @@ class NavBar extends Component {
     });
   }
 
+  handleResize = () => {
+    this.setState({ windowWidth: window.innerWidth });
+  }
+
+  componentDidMount() {
+    window.addEventListener("resize", this.handleResize);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener("resize", this.handleResize);
+  }
+
   render() {
     const { selectedKeys } = this.state;
+    const { windowWidth } = this.state;
+
     return (
-      <Header>
-        <Menu
-          theme="dark"
-          mode="horizontal"
-          selectedKeys={selectedKeys}
-          style={{ lineHeight: '64px' }}
-        >
-          <Menu.Item key="/" onClick={() => this.setSelectedKeys(['/'])}><Link to="/">Home</Link></Menu.Item>
-          <Menu.Item key="/upload-worklog-report" onClick={() => this.setSelectedKeys(['/upload-worklog-report'])}><Link to="/upload-worklog-report">Upload Report</Link></Menu.Item>
-          <Menu.Item key="/view-payroll-report" onClick={() => this.setSelectedKeys(['/view-payroll-report'])}><Link to="/view-payroll-report">View Payroll Report</Link></Menu.Item>
-        </Menu>
-      </Header>
+      <>
+        { windowWidth > mobileWidthBreak ?
+          <Header>
+            <Menu
+              theme="dark"
+              mode="horizontal"
+              selectedKeys={selectedKeys}
+              style={{ lineHeight: '64px' }}
+            >
+              <Menu.Item key="/" onClick={() => this.setSelectedKeys(['/'])}><Link to="/">Home</Link></Menu.Item>
+              <Menu.Item key="/upload-worklog-report" onClick={() => this.setSelectedKeys(['/upload-worklog-report'])}><Link to="/upload-worklog-report">Upload Report</Link></Menu.Item>
+              <Menu.Item key="/view-payroll-report" onClick={() => this.setSelectedKeys(['/view-payroll-report'])}><Link to="/view-payroll-report">View Payroll Report</Link></Menu.Item>
+            </Menu>
+          </Header>
+          :
+          <Sider
+            breakpoint="lg"
+            collapsedWidth="0"
+            onBreakpoint={(broken) => {
+              console.log(broken);
+            }}
+            onCollapse={(collapsed, type) => {
+              console.log(collapsed, type);
+            }}
+          >
+            <Menu
+              theme="dark"
+              mode="inline"
+              selectedKeys={selectedKeys}
+              style={{ lineHeight: '64px' }}
+            >
+              <Menu.Item key="/" onClick={() => this.setSelectedKeys(['/'])}><Link to="/">Home</Link></Menu.Item>
+              <Menu.Item key="/upload-worklog-report" onClick={() => this.setSelectedKeys(['/upload-worklog-report'])}><Link to="/upload-worklog-report">Upload Report</Link></Menu.Item>
+              <Menu.Item key="/view-payroll-report" onClick={() => this.setSelectedKeys(['/view-payroll-report'])}><Link to="/view-payroll-report">View Payroll Report</Link></Menu.Item>
+            </Menu>
+          </Sider>
+        }
+      </>
     );
   }
 }


### PR DESCRIPTION
#### Reference Issues/PRs
This PR resolves issue #47 
#### What does this implement/fix? 
This pull request fixes the navigation bar responsiveness. When website is shrunk or display on mobile is less than 500px in width, the navbar shrinks to collapsible menu.

The original nav bar is kept when window is wider than 500px as seen here:
![2021-03-18 23_54_36-Window](https://user-images.githubusercontent.com/54871513/111744684-d5beb480-8848-11eb-8b41-c52e1c578005.png)

Once the 500px threshold is broken, the nav bar collapses to a mobile friendly navigation bar.
CLOSED:
![2021-03-18 23_55_11-Window](https://user-images.githubusercontent.com/54871513/111745235-8cbb3000-8849-11eb-8d69-b92ab199c3fa.png)
OPEN:
![2021-03-18 23_55_41-Window](https://user-images.githubusercontent.com/54871513/111745461-d99f0680-8849-11eb-98d9-734ed0cd251b.png)

